### PR TITLE
Guard against an undefined/misconfigured requestProperty

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,12 @@ Guard.prototype = {
       var self = this
       var options = self._options
 
+      if (!options.requestProperty) {
+        return next(new UnauthorizedError('request_property_undefined', {
+          message: 'requestProperty hasn\'t been defined. Check your configuration.'
+        }))
+      }
+
       var user = req[options.requestProperty]
       if (!user) return next()
 

--- a/test/test.js
+++ b/test/test.js
@@ -42,6 +42,20 @@ test('permissions array not found', function (t) {
   })
 })
 
+test('invalid requestProperty with custom options', function (t) {
+  var guard = require('../index')({
+    requestProperty: undefined,
+    permissionsProperty: 'scopes'
+  })
+  var req = { identity: { scopes: ['ping'] } }
+  guard.check('ping')(req, res, function (err) {
+    if (!err) return t.end('should throw an error')
+
+    t.ok(err.code === 'request_property_undefined', 'correct error code')
+    t.end()
+  })
+})
+
 test('valid permissions with custom options', function (t) {
   var guard = require('../index')({
     requestProperty: 'identity',


### PR DESCRIPTION
Based on #7, there needs to be a check in place to make sure
requestProperty has been defined, otherwise the middleware could pass on
an invalid request.

Fixes #7.