### PR TITLE
Added ability for deep permissionsProperty

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,13 @@ var PermissionError = new UnauthorizedError(
 var Guard = function (options) {
   var defaults = {
     requestProperty: 'user',
-    permissionsProperty: 'permissions'
+    permissionsProperty: ['permissions']
   }
+
+  if (options != null) {
+    options.permissionsProperty = options.permissionsProperty.split('.')
+  }
+
   this._options = xtend(defaults, options)
 }
 
@@ -38,7 +43,16 @@ Guard.prototype = {
         }))
       }
 
-      var permissions = user[options.permissionsProperty]
+      var permissions = user
+      options.permissionsProperty.forEach(function (key) {
+        try {
+          permissions = permissions[key]
+        } catch (e) {
+          return next(new UnauthorizedError('property_invalid', {
+            message: 'property isn\'t defined. Check your configuration.'
+          }))
+        }
+      })
 
       if (!permissions) {
         return next(new UnauthorizedError('permissions_not_found', {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var util = require('util')
 var xtend = require('xtend')
+var get = require('lodash/get')
 
 var UnauthorizedError = require('./error')
 var PermissionError = new UnauthorizedError(
@@ -9,11 +10,7 @@ var PermissionError = new UnauthorizedError(
 var Guard = function (options) {
   var defaults = {
     requestProperty: 'user',
-    permissionsProperty: ['permissions']
-  }
-
-  if (options != null) {
-    options.permissionsProperty = options.permissionsProperty.split('.')
+    permissionsProperty: 'permissions'
   }
 
   this._options = xtend(defaults, options)
@@ -43,17 +40,7 @@ Guard.prototype = {
         }))
       }
 
-      var permissions = user
-      options.permissionsProperty.forEach(function (key) {
-        try {
-          permissions = permissions[key]
-        } catch (e) {
-          return next(new UnauthorizedError('property_invalid', {
-            message: 'property isn\'t defined. Check your configuration.'
-          }))
-        }
-      })
-
+      var permissions = get(user, options.permissionsProperty, undefined)
       if (!permissions) {
         return next(new UnauthorizedError('permissions_not_found', {
           message: 'Could not find permissions for user. Bad configuration?'

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var util = require('util')
 var xtend = require('xtend')
-var get = require('lodash/get')
+var get = require('lodash.get')
 
 var UnauthorizedError = require('./error')
 var PermissionError = new UnauthorizedError(

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "tap": "^8.0.0"
   },
   "dependencies": {
+    "lodash": "^4.16.6",
     "xtend": "^4.0.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "tap": "^8.0.0"
   },
   "dependencies": {
-    "lodash": "^4.16.6",
+    "lodash.get": "^4.4.2",
     "xtend": "^4.0.1"
   },
   "engines": {

--- a/test/test.js
+++ b/test/test.js
@@ -106,3 +106,37 @@ test('invalid required multiple permissions', function (t) {
     t.end()
   })
 })
+
+test('valid permissions with deep permissionsProperty', function (t) {
+  t.plan(1)
+  var guard = require('../index')({
+    requestProperty: 'identity',
+    permissionsProperty: 'scopes.permissions'
+  })
+  var req = { identity: { scopes: { permissions: ['ping'] } } }
+  guard.check('ping')(req, res, t.error)
+})
+
+test('invalid permissions with deep permissionsProperty', function (t) {
+  var guard = require('../index')({
+    requestProperty: 'identity',
+    permissionsProperty: 'scopes.permissions'
+  })
+  var req = { identity: { scopes: { permissions: ['ping'] } } }
+  guard.check('foo')(req, res, function (err) {
+    if (!err) return t.end('should throw an error')
+
+    t.ok(err.code === 'permission_denied', 'correct error code')
+    t.end()
+  })
+})
+
+test('valid permissions with very deep permissionsProperty', function (t) {
+  t.plan(1)
+  var guard = require('../index')({
+    requestProperty: 'identity',
+    permissionsProperty: 'scopes.permissions.this.is.deep'
+  })
+  var req = { identity: { scopes: { permissions: { this: { is: { deep: ['ping'] } } } } } }
+  guard.check('ping')(req, res, t.error)
+})


### PR DESCRIPTION
Allows "permissionsProperty" to be set for multiple levels deep. 
example:
{
  permissionsProperty = 'identity.permissions'
}

This allows more flexibility with JWT's that may not be able to put
permissions on the top level.