### PR TITLE
Super permissions

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var Guard = function (options) {
 
 Guard.prototype = {
 
-  check: function (required, superPermission = null) {
+  check: function (required, superPermission) {
     if (typeof required === 'string') required = [required]
 
     return _middleware.bind(this)

--- a/index.js
+++ b/index.js
@@ -20,10 +20,11 @@ Guard.prototype = {
 
   check: function (required, superPermission) {
     if (typeof required === 'string') required = [required]
+    if (typeof superPermission === 'string') superPermission = [superPermission];
 
     return _middleware.bind(this)
 
-    function _middleware (req, res, next) {
+    function _middleware(req, res, next) {
       var self = this
       var options = self._options
 
@@ -56,10 +57,11 @@ Guard.prototype = {
           message: 'Permissions should be an Array or String. Bad format?'
         }))
       }
-      if (permissions.indexOf(superPermission) !== -1) {
-        return next(false)
+      for (var i = 0; i < superPermission.length; i++) {
+        if (permissions.indexOf(superPermission[i]) !== -1) {
+          return next(false)
+        }
       }
-
       var sufficient = required.every(function (permission) {
         return permissions.indexOf(permission) !== -1
       })

--- a/index.js
+++ b/index.js
@@ -57,9 +57,11 @@ Guard.prototype = {
           message: 'Permissions should be an Array or String. Bad format?'
         }))
       }
-      for (var i = 0; i < superPermission.length; i++) {
-        if (permissions.indexOf(superPermission[i]) !== -1) {
-          return next(false)
+      if (superPermission) {
+        for (var i = 0; i < superPermission.length; i++) {
+          if (permissions.indexOf(superPermission[i]) !== -1) {
+            return next(false)
+          }
         }
       }
       var sufficient = required.every(function (permission) {

--- a/index.js
+++ b/index.js
@@ -59,7 +59,6 @@ Guard.prototype = {
       }
       if (superPermission) {
         for (var i = 0; i < superPermission.length; i++) {
-          console.log('Checking permission', superPermission[i], permissions.indexOf(superPermission[i]) !== -1);
           if (permissions.indexOf(superPermission[i]) !== -1) {
             return next(false);
           }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var Guard = function (options) {
 
 Guard.prototype = {
 
-  check: function (required) {
+  check: function (required, superPermission = null) {
     if (typeof required === 'string') required = [required]
 
     return _middleware.bind(this)
@@ -55,6 +55,9 @@ Guard.prototype = {
         return next(new UnauthorizedError('permissions_invalid', {
           message: 'Permissions should be an Array or String. Bad format?'
         }))
+      }
+      if (permissions.indexOf(superPermission) !== -1) {
+        return next(false)
       }
 
       var sufficient = required.every(function (permission) {

--- a/index.js
+++ b/index.js
@@ -59,8 +59,9 @@ Guard.prototype = {
       }
       if (superPermission) {
         for (var i = 0; i < superPermission.length; i++) {
+          console.log('Checking permission', superPermission[i], permissions.indexOf(superPermission[i]) !== -1);
           if (permissions.indexOf(superPermission[i]) !== -1) {
-            return next(false)
+            return next(false);
           }
         }
       }

--- a/test/test.js
+++ b/test/test.js
@@ -146,3 +146,9 @@ test('OAuth space-delimited scopes', function (t) {
   var req = { user: { permissions: 'ping foo bar' } }
   guard.check('foo')(req, res, t.error)
 })
+
+test('super permissions', function (t) {
+  t.plan(1)
+  var req = { user: { permissions: ['admin'] } }
+  guard.check('ping', 'admin')(req, res, t.error)
+})


### PR DESCRIPTION
Added support for super permissions.

Super permissions allow a user of the library to express OR requirements for a given route. For example: 

We could have a route that requires the permission "team". However, using the super permission "admin" we can allow any user with the "admin" permission to access the route without explicitly holding the "team" permission.

Currently, there can only be one super permission. This could be expanded upon to allow a list of super permissions.