### PR TITLE
Boolean logic AND/OR

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,39 @@ app.get('/status', guard.check('status'), function(req, res) { ... })
 app.get('/user', guard.check(['user:read']), function(req, res) { ... })
 ```
 
+Logical combinations of required permissions can be made using nested arrays.
+
+Single string
+```js
+// Required: "admin"
+app.use(guard.check(
+  'admin'
+))
+```
+
+Array of strings
+```js
+// Required: "read" AND "write"
+app.use(guard.check(
+  ['read', 'write']
+))
+```
+
+Array of arrays of strings
+```js
+// Required: "read" OR "write"
+app.use(guard.check([
+  ['read'],
+  ['write']
+]))
+
+// Required: "admin" OR ("read" AND "write")
+app.use(guard.check([
+  ['admin'],
+  ['read', 'write']
+]))
+```
+
 ### Configuration
 To set where the module can find the user property (default `req.user`) you can set the `requestProperty` option.
 

--- a/index.js
+++ b/index.js
@@ -16,10 +16,22 @@ var Guard = function (options) {
   this._options = xtend(defaults, options)
 }
 
+function isString (value) {
+  return typeof value === 'string'
+}
+
+function isArray (value) {
+  return value instanceof Array
+}
+
 Guard.prototype = {
 
   check: function (required) {
-    if (typeof required === 'string') required = [required]
+    if (isString(required)) {
+      required = [[required]]
+    } else if (isArray(required) && required.every(isString)) {
+      required = [required]
+    }
 
     return _middleware.bind(this)
 
@@ -57,8 +69,10 @@ Guard.prototype = {
         }))
       }
 
-      var sufficient = required.every(function (permission) {
-        return permissions.indexOf(permission) !== -1
+      var sufficient = required.some(function (required) {
+        return required.every(function (permission) {
+          return permissions.indexOf(permission) !== -1
+        })
       })
 
       return next(!sufficient ? PermissionError : null)

--- a/test/test.js
+++ b/test/test.js
@@ -146,3 +146,37 @@ test('OAuth space-delimited scopes', function (t) {
   var req = { user: { permissions: 'ping foo bar' } }
   guard.check('foo')(req, res, t.error)
 })
+
+test('valid boolean "OR" with single required permissions', function (t) {
+  t.plan(1)
+  var req = { user: { permissions: 'ping foo bar' } }
+  guard.check([['nope'], ['ping']])(req, res, t.error)
+})
+
+test('valid boolean "OR" with single and multiple required permissions', function (t) {
+  t.plan(1)
+  var req = { user: { permissions: 'ping foo bar' } }
+  guard.check([['nope'], ['ping', 'foo']])(req, res, t.error)
+})
+
+test('invalid boolean "OR" with single required permissions', function (t) {
+  t.plan(1)
+  var req = { user: { permissions: 'ping foo bar' } }
+  guard.check([['nope'], ['nada']])(req, res, function (err) {
+    if (!err) return t.end('should throw an error')
+
+    t.ok(err.code === 'permission_denied', 'correct error code')
+    t.end()
+  })
+})
+
+test('invalid boolean "OR" with multiple partial required permissions', function (t) {
+  t.plan(1)
+  var req = { user: { permissions: 'ping foo bar' } }
+  guard.check([['nope', 'foo'], ['nada', 'bar']])(req, res, function (err) {
+    if (!err) return t.end('should throw an error')
+
+    t.ok(err.code === 'permission_denied', 'correct error code')
+    t.end()
+  })
+})


### PR DESCRIPTION
Adding a way to configure combinations of permissions (scopes). For example: a user might have "read" permission, while a trusted microservice would have a "full_access" permission.

Backwards compatible, non-breaking change.

Related: #12 #21 #20