### PR TITLE
Fix typings for tsc esModuleInterop=false

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,4 +13,7 @@ declare class Guard {
 
 declare function guardFactory(options: GuardOptions): Guard;
 
+declare namespace guardFactory {
+}
+
 export = guardFactory;


### PR DESCRIPTION
Fix typings when the compilation options don't have "esModuleInterop" enabled.

The existing typings only works when "esModuleInterop" is enabled in the compilation options. i.e.

```
import guardFactory from 'express-jwt-permissions'
```

However, some repositories don't have "esModuleInterop" enabled for compatibility reasons. i.e.

```
import * as guardFactory from 'express-jwt-permissions'
```

And the error `error TS2497: This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export.` is raised on a compilation.

This change fixes the error and makes it also work in the environment doesn't' have "esModuleInterop" enabled.