### PR TITLE
Optional GuardOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,12 +6,12 @@ declare interface GuardOptions {
 }
 
 declare class Guard {
-  public constructor(options: GuardOptions);
+  public constructor(options?: GuardOptions);
 
   public check(required: string | string[] | string[][]): Handler;
 }
 
-declare function guardFactory(options: GuardOptions): Guard;
+declare function guardFactory(options?: GuardOptions): Guard;
 
 declare namespace guardFactory {
 }


### PR DESCRIPTION
The documentation allows calling the `guardFactory` function without any options. The option can safely be marked optional since the line below sets default options.
https://github.com/MichielDeMey/express-jwt-permissions/blob/2e91562ca9cde7a6f5f830f14a7f0b99ca54caa2/index.js#L15