### PR TITLE
Compatibility for browsers that are not v8 enabled

### DIFF
--- a/error.js
+++ b/error.js
@@ -1,7 +1,11 @@
 const util = require('util')
 
 module.exports = function UnauthorizedError (code, error) {
-  Error.captureStackTrace(this, this.constructor)
+  if (!Error.captureStackTrace){
+    this.stack = (new Error()).stack;
+  }else {
+    Error.captureStackTrace(this, this.constructor);
+  }
 
   this.name = this.constructor.name
   this.message = error.message


### PR DESCRIPTION
Inspiration: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error and https://stackoverflow.com/questions/1382107/whats-a-good-way-to-extend-error-in-javascript

I think this is a great addition. I faced this error with firefox and managed to get it through by adding the check.